### PR TITLE
Include a PR template

### DIFF
--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+
+Thank you for your contribution!
+
+To keep this project of high quality, please make sure to tick all the
+following boxes before sending your pull request.
+
+Your pull request will automatically have its tests run and spelling checked,
+but if you would like to run these checks locally, you can do so:
+
+Run your tests locally with:
+
+    nix-build channel/tests && ./result
+    nix-build tests && ./result
+
+Check the spelling of your documentation with codespell:
+
+    git ls-files | nix-shell -p findutils codespell --run "xargs codespell -q 2"
+
+-->
+
+- [ ] I have created a test to cover the new behavior.    
+- [ ] I have written and updated relevant documentation, including updating this
+      pull request template if necessary. Note that we try to follow the
+      [Divio documentation](https://documentation.divio.com/) of documentation.
+      


### PR DESCRIPTION
Specifically, add tick-boxes asking for documentation and tests to the template people fill out when they file a PR.