### PR TITLE
buildRustPackage: set cargoDepsName attribute

### DIFF
--- a/pkgs/buildRustPackage.nix
+++ b/pkgs/buildRustPackage.nix
@@ -1,8 +1,14 @@
 { rustPlatform, lib, meta }:
 { project, ... }@args:
 let source = meta.getBuilderSource project args;
-in rustPlatform.buildRustPackage (args // {
+in rustPlatform.buildRustPackage (args // rec {
   inherit (source) pname version src;
+
+  # Ensure that the cargoDeps path and checksum don't change with
+  # the change of `name` that occurs with version changes.
+  # - https://github.com/NixOS/nixpkgs/issues/112763
+  # - https://github.com/NixOS/nixpkgs/pull/113176
+  cargoDepsName = pname;
 
   # This for one sets meta.position to where the project is defined
   pos = builtins.unsafeGetAttrPos "project" args;


### PR DESCRIPTION
We set the cargoDepsName attribute to prevent the path of the cargoDeps
package from changing when there is a change of version, such as that
which happens when building manually with `flox build` (in which case
the version string is set to "-manual").

<!--

Thank you for your contribution!

To keep this project of high quality, please make sure to tick all the
following boxes before sending your pull request.

Your pull request will automatically have its tests run and spelling checked,
but if you would like to run these checks locally, you can do so:

Run your tests locally with:

    nix-build channel/tests && ./result
    nix-build tests && ./result

Check the spelling of your documentation with codespell:

    git ls-files | nix-shell -p findutils codespell --run "xargs codespell -q 2"

Reformat your changes with nixfmt:

    git ls-files | grep '.nix$' | nix-shell -p findutils nixfmt --run "xargs nixfmt"

-->

- [ ] I have created a test to cover the new behavior.
- [ ] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

